### PR TITLE
Drop trigger on terraform outputs.

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -89,7 +89,6 @@ jobs:
     - get: common
       trigger: true
     - get: terraform-yaml
-      trigger: true
     - get: stemcell
       trigger: true
     - get: uaa-release


### PR DESCRIPTION
Prevents extra deploys that can lead to downtime or errors on uaa custom
templates.