### PR TITLE
Update production concourse oauth redirect uri.

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -78,7 +78,7 @@ instance_groups:
             <<: *client-template
             scope: openid,concourse.admin
             authorities: uaa.none,concourse.admin
-            redirect-uri: https://ci.fr.cloud.gov/auth/oauth/callback
+            redirect-uri: https://ci.fr.cloud.gov/sky/issuer/callback
             secret: ((concourse_client_secret_production))
 
           # Platform kibana auth


### PR DESCRIPTION
Merge with https://github.com/18F/cg-deploy-concourse/pull/99.