### PR TITLE
added clients for doomsday.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 opsuaa.yml
+.idea/
+.vscode/

--- a/manifest.yml
+++ b/manifest.yml
@@ -116,6 +116,16 @@ instance_groups:
             scope: openid,email,profile
             redirect-uri: https://prometheus.fr.cloud.gov/oauth2/callback,https://alertmanager.fr.cloud.gov/oauth2/callback,https://grafana.fr.cloud.gov/oauth2/callback
             secret: ((prometheus_client_secret_production))
+          doomsday-staging:
+            <<: *client-template
+            scope: openid,email,profile
+            redirect-uri: https://doomsday.fr-stage.cloud.gov/oauth2/idpresponse
+            secret: ((doomsday_client_secret_staging))
+          doomsday-production:
+            <<: *client-template
+            scope: openid,email,profile
+            redirect-uri: https://doomsday.fr.cloud.gov/oauth2/idpresponse
+            secret: ((doomsday_client_secret_production))
         login: {client_secret: ((uaa_login_client_secret))}
         zones: {internal: {hostnames: []}}
       login:
@@ -182,6 +192,10 @@ variables:
 - name: prometheus_client_secret_staging
   type: password
 - name: prometheus_client_secret_production
+  type: password
+- name: doomsday_client_secret_staging
+  type: password
+- name: doomsday_client_secret_production
   type: password
 - name: uaa_encryption_key_1
   type: password


### PR DESCRIPTION
Added new clients for doomsday OIDC logins with proper [redirect urls](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/listener-authenticate-users.html).

Signed-off-by: Mike Lloyd <mike.lloyd@gsa.gov>